### PR TITLE
fix permission for newsletter managers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,12 @@ Changelog
 3.1.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix "Gestore Newsletter" role: stop granting the generic "Add portal
+  content" permission site-wide, which unintentionally let the role add any
+  content type protected by it (e.g. "Venue"/"Luogo", "Bando"), not just
+  newsletters. Grant it back, locally, only on Channels via the
+  channel_workflow.
+  [fedevancin]
 
 
 3.1.6 (2026-06-17)

--- a/src/rer/newsletter/profiles/default/metadata.xml
+++ b/src/rer/newsletter/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>1006</version>
+  <version>1007</version>
   <dependencies>
     <dependency>profile-plone.app.tiles:default</dependency>
   </dependencies>

--- a/src/rer/newsletter/profiles/default/rolemap.xml
+++ b/src/rer/newsletter/profiles/default/rolemap.xml
@@ -10,10 +10,13 @@
       <role name="Manager" />
       <role name="Site Administrator" />
     </permission>
-    <permission acquire="False"
+    <permission acquire="True"
                 name="rer.newsletter: Add Message"
     >
-</permission>
+      <role name="Manager" />
+      <role name="Site Administrator" />
+      <role name="Gestore Newsletter" />
+    </permission>
     <permission acquire="True"
                 name="rer.newsletter: Manage Newsletter"
     >
@@ -42,7 +45,6 @@
       <role name="Site Administrator" />
       <role name="Owner" />
       <role name="Contributor" />
-      <role name="Gestore Newsletter" />
     </permission>
   </permissions>
 </rolemap>

--- a/src/rer/newsletter/profiles/default/workflows/channel_workflow/definition.xml
+++ b/src/rer/newsletter/profiles/default/workflows/channel_workflow/definition.xml
@@ -8,6 +8,7 @@
 >
 
   <permission>Access contents information</permission>
+  <permission>Add portal content</permission>
   <permission>Delete objects</permission>
   <permission>Modify portal content</permission>
   <permission>Request review</permission>
@@ -31,6 +32,14 @@
       <permission-role>Site Administrator</permission-role>
     </permission-map>
     <permission-map acquired="True"
+                    name="Add portal content"
+    >
+      <permission-role>Editor</permission-role>
+      <permission-role>Gestore Newsletter</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map acquired="True"
                     name="Delete objects"
     >
       <permission-role>Gestore Newsletter</permission-role>
@@ -38,6 +47,7 @@
     <permission-map acquired="False"
                     name="Modify portal content"
     >
+      <permission-role>Gestore Newsletter</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>Owner</permission-role>
       <permission-role>Site Administrator</permission-role>
@@ -69,6 +79,7 @@
                     name="rer.newsletter: Add Message"
     >
       <permission-role>Editor</permission-role>
+      <permission-role>Gestore Newsletter</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
@@ -86,6 +97,14 @@
       <permission-role>Anonymous</permission-role>
     </permission-map>
     <permission-map acquired="True"
+                    name="Add portal content"
+    >
+      <permission-role>Contributor</permission-role>
+      <permission-role>Gestore Newsletter</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map acquired="True"
                     name="Delete objects"
     >
       <permission-role>Gestore Newsletter</permission-role>
@@ -93,6 +112,7 @@
     <permission-map acquired="False"
                     name="Modify portal content"
     >
+      <permission-role>Gestore Newsletter</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>Owner</permission-role>
       <permission-role>Site Administrator</permission-role>
@@ -118,6 +138,7 @@
                     name="rer.newsletter: Add Message"
     >
       <permission-role>Contributor</permission-role>
+      <permission-role>Gestore Newsletter</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>

--- a/src/rer/newsletter/upgrades.py
+++ b/src/rer/newsletter/upgrades.py
@@ -8,7 +8,6 @@ from zope.annotation.interfaces import IAnnotations
 
 import re
 
-
 default_profile = "profile-rer.newsletter:default"
 
 KEY = "rer.newsletter.channel.history"
@@ -101,10 +100,52 @@ def migrate_to_1006(context):
     to_remove = "plone.richtext"
     to_add = "volto.blocks"
     portal_types = api.portal.get_tool(name="portal_types")
-    behaviors = [x for x in portal_types["Message"].behaviors if x != to_remove]
+    behaviors = [
+        x for x in portal_types["Message"].behaviors if x != to_remove
+    ]
     behaviors.append(to_add)
     portal_types["Message"].behaviors = tuple(behaviors)
 
     # change view
     portal_types["Message"].default_view = "view"
     portal_types["Message"].view_methods = ["view"]
+
+
+def _update_channel_role_mappings():
+    """
+    Recompute the workflow-derived local permissions on existing Channels.
+
+    ``updateRoleMappingsFor`` lives on the workflow *definition*
+    (e.g. ``channel_workflow``), not on ``portal_workflow`` itself, so it
+    has to be looked up per-object via ``getWorkflowsFor``.
+    """
+    workflow_tool = api.portal.get_tool("portal_workflow")
+    for brain in api.content.find(portal_type="Channel"):
+        obj = brain.getObject()
+        for wf in workflow_tool.getWorkflowsFor(obj):
+            if hasattr(wf, "updateRoleMappingsFor"):
+                wf.updateRoleMappingsFor(obj)
+
+
+def migrate_to_1007(context):
+    """
+    Fix "Gestore Newsletter" permissions.
+
+    The role used to be granted the generic "Add portal content" permission
+    site-wide, which unintentionally let a Newsletter Manager add any
+    content type protected by it (e.g. "Venue"/"Luogo", "Bando"), not just
+    newsletters.
+
+    Two things are needed to fix this without breaking newsletter creation:
+
+    - Stop granting "Add portal content" site-wide, and grant the properly
+      scoped "rer.newsletter: Add Message" permission instead.
+    - Grant "Add portal content" and "Modify portal content" back, locally,
+      only on Channels (via channel_workflow).
+    """
+    setup_tool = api.portal.get_tool("portal_setup")
+    setup_tool.runImportStepFromProfile(default_profile, "rolemap")
+    setup_tool.runImportStepFromProfile(default_profile, "workflow")
+
+    _update_channel_role_mappings()
+    logger.info("Updated to 1007")

--- a/src/rer/newsletter/upgrades.zcml
+++ b/src/rer/newsletter/upgrades.zcml
@@ -55,4 +55,12 @@
       destination="1006"
       handler=".upgrades.migrate_to_1006"
       />
+  <genericsetup:upgradeStep
+      title="Upgrade rer.newsletter to 1007"
+      description="Stop granting 'Gestore Newsletter' the generic 'Add portal content' permission site-wide; grant it, and 'Modify portal content', back locally on Channel only, alongside the scoped 'rer.newsletter: Add Message' permission"
+      profile="rer.newsletter:default"
+      source="1006"
+      destination="1007"
+      handler=".upgrades.migrate_to_1007"
+      />
 </configure>


### PR DESCRIPTION
Fix "Gestore Newsletter" role: stop granting the generic "Add portal content" permission site-wide, which unintentionally let the role add any content type protected by it (e.g. "Venue"/"Luogo", "Bando"), not just newsletters. Grant it back, locally, only on Channels via the channel_workflow.